### PR TITLE
Feature alternative time merged com master

### DIFF
--- a/quiz_unity/Assets/Scripts/Constant/GameMechanicsConstant.cs
+++ b/quiz_unity/Assets/Scripts/Constant/GameMechanicsConstant.cs
@@ -19,9 +19,16 @@ public static class GameMechanicsConstant
         BackgroundAndKill = 2
     }
 
+    public enum VisualSliderChange
+    {
+        Linear = 0,
+        Polynomial = 1,
+        Exponential = 2
+    }
+
     public static readonly int PowerUpCount = Enum.GetNames(typeof(PowerUpNames)).Length;
 
-    public static readonly float AnswerConfirmationTimeinSeconds = 2.0f;
+    public static readonly float AnswerConfirmationTimeinSeconds = 1.5f;
     public static readonly float FeedbackPowerUpAnimationTimeiNSeconds = 2.0f;
 
     public static readonly float IceAnimationTimeinSeconds = 1.5f;

--- a/quiz_unity/Assets/Scripts/Constant/GameMechanicsConstant.cs
+++ b/quiz_unity/Assets/Scripts/Constant/GameMechanicsConstant.cs
@@ -29,4 +29,5 @@ public static class GameMechanicsConstant
     public static readonly float LeafAnimationTimeinSeconds = 2.0f;
 
     public static readonly float TimeToAnswerQuestion = 45.0f;
+    public static readonly float TimeToAnswerQuestionAfterLeafPowerUp = 30.0f;
 }

--- a/quiz_unity/Assets/Scripts/Gameplay/Controllers/GameController.cs
+++ b/quiz_unity/Assets/Scripts/Gameplay/Controllers/GameController.cs
@@ -403,8 +403,11 @@ public class GameController : MonoBehaviour
 				Debug.Log("Form upload complete!");
 			}
 
-			www.downloadHandler.Dispose();
-			www.uploadHandler.Dispose();
+			// www.downloadHandler.Dispose();
+			www.disposeCertificateHandlerOnDispose = true;
+			www.disposeDownloadHandlerOnDispose = true;
+			www.disposeUploadHandlerOnDispose = true;
+			// www.uploadHandler.Dispose();
 			www.Dispose();
 		}
 		Debug.Log("Depois Form");

--- a/quiz_unity/Assets/Scripts/UI/AnswerButton.cs
+++ b/quiz_unity/Assets/Scripts/UI/AnswerButton.cs
@@ -45,7 +45,7 @@ public class AnswerButton : MonoBehaviour
 		{
 			// questionClock.NewCountdown(dataController.GetComponent<DataController>().RetrieveQuiz().GetQuestionData().QuestionTime);
 			StartCoroutine(powerUpController.PowerUpFolhaAnim());
-			questionClock.NewCountdown(30);
+			questionClock.NewCountdown(GameMechanicsConstant.TimeToAnswerQuestionAfterLeafPowerUp);
 			eventManager.LetAnswerQuestion();
 			eventManager.ResetLastAnswerButton();
 			powerUpController.LeafPowerExpired();

--- a/quiz_unity/Assets/Scripts/UI/EventManager.cs
+++ b/quiz_unity/Assets/Scripts/UI/EventManager.cs
@@ -16,7 +16,7 @@ public class EventManager : MonoBehaviour
 
     private List<GameObject> answerButtonList;
 
-    public float answerConfirmation = GameMechanicsConstant.AnswerConfirmationTimeinSeconds;   
+    public float answerConfirmationTime = GameMechanicsConstant.AnswerConfirmationTimeinSeconds;   
 
     private AnswerButton selectedAnswerButton;
     private Slider progressSlider;
@@ -33,6 +33,8 @@ public class EventManager : MonoBehaviour
         holdTouchClock = new PressClock(0);
 
         audioSource = GetComponent<AudioSource>();
+
+        SliderFunctionValue.SetCalculationMode(GameMechanicsConstant.VisualSliderChange.Linear); // linear or polynomial or exponential
     }
 
     public void Update()
@@ -40,15 +42,20 @@ public class EventManager : MonoBehaviour
         if(wasTouched && !idleState)
         {
             Touch touch = Input.GetTouch(0);
+
+            // Update of the clock touching.
             holdTouchClock.IncreaseTime(Time.deltaTime);
 
             if(!audioSource.isPlaying) audioSource.PlayOneShot(touchingClip);
 
-            progressSlider.value = Math.Min(holdTouchClock.Time / answerConfirmation, 1);
+            // Update selection change (Orange bar - visual only)
+            progressSlider.value = Math.Min((float) SliderFunctionValue.ProgressCalculation(holdTouchClock.Time), 1.0f);
 
-            if(holdTouchClock.Time >= answerConfirmation)
+            Debug.Log("BEFORE F(X) -> " + progressSlider.value);
+            if (holdTouchClock.Time >= answerConfirmationTime)
             {
-                
+                Debug.Log("Holdtouch Time -> " + holdTouchClock.Time);
+                Debug.Log("AFTER F(X) -> " + progressSlider.value);
                 resetSlider();
                 resetTouchClock();
                 selectedAnswerButton.GetComponent<AnswerButton>().HandleClick(QuestionClock);
@@ -64,6 +71,26 @@ public class EventManager : MonoBehaviour
             }
         }
     }
+
+    // SliderCalculation from Interface
+
+    public float ProgressCalculation(float totalTimeElapsed)
+    {
+        // (8/21) * (X^3 - X^2 + X)
+
+        return (
+            ((totalTimeElapsed) * (totalTimeElapsed) * (totalTimeElapsed)) -
+            ((totalTimeElapsed) * (totalTimeElapsed)) +
+             (totalTimeElapsed)
+            ) * (8.0f / 21.0f);
+            
+    }
+    public float UpdateSliderValue(float totalTimeElapsed)
+    {
+        return ProgressCalculation(totalTimeElapsed);
+    }
+
+
 
     // Called from AnswerButton object as pointdown event.
     public void buttonTouched(AnswerButton answerButton)

--- a/quiz_unity/Assets/Scripts/UI/EventManager.cs
+++ b/quiz_unity/Assets/Scripts/UI/EventManager.cs
@@ -90,21 +90,25 @@ public class EventManager : MonoBehaviour
         }
     }
 
+    // Flag to allow the user to answer question
     public void LetAnswerQuestion()
     {
         idleState = true;
     }
 
+    // Flag for locking user's answer
     public void LockAnswer()
     {
         idleState = false;
     }
 
+    // Acces to touch status
     public bool TouchLastStatus()
     {
         return wasTouched;
     }
 
+    // Access to the status of the possibility of answer
     public bool AllowedToAnswer()
     {
         return idleState;

--- a/quiz_unity/Assets/Scripts/UI/SliderFunctionValue.cs
+++ b/quiz_unity/Assets/Scripts/UI/SliderFunctionValue.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class SliderFunctionValue 
+{
+
+    // After y = F(X) is calulated, we need to multiply by number tom kae sure that F(1.5) = 1.0;
+    private static double normalizingFactor;
+
+
+    // Linear? Exponential? Polynomial?
+    private static GameMechanicsConstant.VisualSliderChange currentMode = GameMechanicsConstant.VisualSliderChange.Linear;
+
+    public static void SetCalculationMode(GameMechanicsConstant.VisualSliderChange mode)
+    {
+        currentMode = mode;
+        SetNormalizingFactor();
+    }
+
+    public static float ProgressCalculation(float totalTimeElapsed)
+    {
+        switch (currentMode)
+        {
+            case GameMechanicsConstant.VisualSliderChange.Linear:
+                return (float) LineFunctionCalculation(totalTimeElapsed);
+            case GameMechanicsConstant.VisualSliderChange.Polynomial:
+                return (float) PolynomialFunctionCalculation(totalTimeElapsed);
+            case GameMechanicsConstant.VisualSliderChange.Exponential:
+                return (float) ExponentialFunctionCalculation(totalTimeElapsed);
+            default:
+                Debug.Log("ERRO: Modo não reconhecido. Aplicando modo linear...");
+                return (float) LineFunctionCalculation(totalTimeElapsed);
+        }
+    }
+
+    private static void SetNormalizingFactor()
+    {
+        switch (currentMode)
+        {
+            case GameMechanicsConstant.VisualSliderChange.Linear:
+                normalizingFactor = (2.0f / 3.0f);
+                break;
+            case GameMechanicsConstant.VisualSliderChange.Polynomial:
+                normalizingFactor = (8.0f / 21.0f);
+                break;
+            case GameMechanicsConstant.VisualSliderChange.Exponential:
+                normalizingFactor = (0.54691816067);
+                Debug.Log("");
+                break;
+            default:
+                normalizingFactor = (2.0f / 3.0f);
+                Debug.Log("ERRO: Modo não reconhecido. Aplicando modo linear...");
+                break;
+        }
+
+    }
+
+    private static double LineFunctionCalculation(float totalTimeElapsed)
+    {
+        // F(X) = (X) * 1.5)
+
+        return (totalTimeElapsed) * normalizingFactor;
+    }
+
+    private static double PolynomialFunctionCalculation(float totalTimeElapsed)
+    {
+        // (8/21) * (X^3 - X^2 + X)
+
+        return (
+            ((totalTimeElapsed) * (totalTimeElapsed) * (totalTimeElapsed)) -
+            ((totalTimeElapsed) * (totalTimeElapsed)) +
+             (totalTimeElapsed)
+            ) * (normalizingFactor);
+
+    }
+
+    private static double ExponentialFunctionCalculation(float totalTimeElapsed)
+    {
+        // (2^x - 1) * 0.54691816067
+
+        return (Mathf.Pow(2, totalTimeElapsed) - 1) * (normalizingFactor);
+    }
+}


### PR DESCRIPTION
- Tempo necessário para segurar uma alternativa para confirmar a resposta foi diminuído de 2,0s para 1,5s
- Reestruturação da apresentação visual da alternativa: a barra laranja agora cresce de acordo com uma função (linear, exponencial ou polinomial), observando o tempo necessário para confirmar a resposta.